### PR TITLE
Configure tests with context by default

### DIFF
--- a/src/test/kotlin/org/example/detekt/MyRuleTest.kt
+++ b/src/test/kotlin/org/example/detekt/MyRuleTest.kt
@@ -1,8 +1,13 @@
 package org.example.detekt
 
 import com.google.common.truth.Truth.assertThat
+import io.github.detekt.test.utils.KotlinCoreEnvironmentWrapper
+import io.github.detekt.test.utils.createEnvironment
 import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
+import org.junit.After
+import org.junit.Before
 import org.junit.Test
 
 internal class CustomRuleSpec {
@@ -14,7 +19,7 @@ internal class CustomRuleSpec {
           inner class B
         }
         """
-        val findings = MyRule(Config.empty).compileAndLint(code)
+        val findings = MyRule(Config.empty).compileAndLintWithContext(env, code)
         assertThat(findings).hasSize(1)
     }
 
@@ -25,7 +30,21 @@ internal class CustomRuleSpec {
           class B
         }
         """
-        val findings = MyRule(Config.empty).compileAndLint(code)
+        val findings = MyRule(Config.empty).compileAndLintWithContext(env, code)
         assertThat(findings).isEmpty()
+    }
+
+    private lateinit var envWrapper: KotlinCoreEnvironmentWrapper
+    private val env: KotlinCoreEnvironment
+        get() = envWrapper.env
+
+    @Before
+    fun setUp() {
+        envWrapper = createEnvironment()
+    }
+
+    @After
+    fun tearDown() {
+        envWrapper.dispose()
     }
 }

--- a/src/test/kotlin/org/example/detekt/MyRuleTest.kt
+++ b/src/test/kotlin/org/example/detekt/MyRuleTest.kt
@@ -6,8 +6,8 @@ import io.github.detekt.test.utils.createEnvironment
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
-import org.junit.After
-import org.junit.Before
+import org.junit.AfterClass
+import org.junit.BeforeClass
 import org.junit.Test
 
 internal class CustomRuleSpec {
@@ -34,17 +34,22 @@ internal class CustomRuleSpec {
         assertThat(findings).isEmpty()
     }
 
-    private lateinit var envWrapper: KotlinCoreEnvironmentWrapper
     private val env: KotlinCoreEnvironment
         get() = envWrapper.env
 
-    @Before
-    fun setUp() {
-        envWrapper = createEnvironment()
-    }
+    companion object {
+        private lateinit var envWrapper: KotlinCoreEnvironmentWrapper
 
-    @After
-    fun tearDown() {
-        envWrapper.dispose()
+        @BeforeClass
+        @JvmStatic
+        fun setUp() {
+            envWrapper = createEnvironment()
+        }
+
+        @AfterClass
+        @JvmStatic
+        fun tearDown() {
+            envWrapper.dispose()
+        }
     }
 }


### PR DESCRIPTION
It's easier to remove it than figure out how to configure it.

fixes #2