### PR TITLE
Bump up actions/checkout to v3

### DIFF
--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -19,7 +19,7 @@ jobs:
 
       # Check out current repository
       - name: Fetch Sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       # Cleanup project
       - name: Cleanup
         run: |

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -13,6 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout latest code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Validate Gradle Wrapper
         uses: gradle/wrapper-validation-action@v1

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Run tests
         uses: gradle/gradle-build-action@v2
         with:
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Check that the publish plugin works
         uses: gradle/gradle-build-action@v2
         with:
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Compile the snippets in the tests
         uses: gradle/gradle-build-action@v2
         with:


### PR DESCRIPTION
Hello, thanks for sharing this useful template! 🙌 

I found that this repo depends on outdated actions that brings several warnings to the workflow run:

![image](https://user-images.githubusercontent.com/505751/211438453-4e40e78a-eaff-47e1-8ed2-f88fdfabb20f.png)

So here I'll suggest a small change to use the latest action running on Node 16. Thanks for checking this PR!