### PR TITLE
Support java 8 by default

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,7 +21,7 @@ dependencies {
 }
 
 tasks.withType<KotlinCompile>() {
-    kotlinOptions.jvmTarget = "11"
+    kotlinOptions.jvmTarget = "1.8"
 }
 
 tasks.withType<Test>().configureEach {


### PR DESCRIPTION
We should keep this aligned with detekt